### PR TITLE
uses arc4random() in aq_hw_init_ucp() of aq_hw.c

### DIFF
--- a/aq_hw.c
+++ b/aq_hw.c
@@ -160,7 +160,7 @@ static int aq_hw_init_ucp(struct aq_hw *hw)
             unsigned int rnd = 0;
             unsigned int ucp_0x370 = 0;
 
-            rnd = random();
+            rnd = arc4random();
 
             ucp_0x370 = 0x02020202 | (0xFEFEFEFE & rnd);
             AQ_WRITE_REG(hw, AQ_HW_UCP_0X370_REG, ucp_0x370);


### PR DESCRIPTION
 uses arc4random() instead of random() in aq_hw_init_ucp() of aq_hw.c; analogous to patch in FreeBSD port 0.0.5 revision 1