### PR TITLE
Fix build on FreeBSD 13 stable

### DIFF
--- a/aq_hw.c
+++ b/aq_hw.c
@@ -32,7 +32,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <unistd.h>
 #include <sys/endian.h>
 #include <sys/param.h>
 #include <sys/systm.h>


### PR DESCRIPTION
pause() has 2 different definition in unistd.h and sys/systm.h