### PR TITLE
Remove #include of user header <unistd.h>

### DIFF
--- a/aq_hw.c
+++ b/aq_hw.c
@@ -32,7 +32,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <unistd.h>
 #include <sys/endian.h>
 #include <sys/param.h>
 #include <sys/systm.h>


### PR DESCRIPTION
The build failed with:

/usr/include/sys/systm.h:437:1: error: static declaration of 'pause'
                                follows non-static declaration
  437 | pause(const char *wmesg, int timo)
      | ^